### PR TITLE
Make DEFAULTED-VALUE return two values

### DIFF
--- a/config.lisp
+++ b/config.lisp
@@ -63,9 +63,8 @@
 (defgeneric defaulted-value (default &rest path)
   (:method (default &rest path)
     (multiple-value-bind (value found) (apply #'value path)
-      (if found
-          value
-          (apply #'(setf value) default path)))))
+      (values (if found value (apply #'(setf value) default path))
+              t))))
 
 (defgeneric call-with-transaction (function &key storage type designator)
   (:method (function &key storage type designator)

--- a/config.lisp
+++ b/config.lisp
@@ -63,8 +63,9 @@
 (defgeneric defaulted-value (default &rest path)
   (:method (default &rest path)
     (multiple-value-bind (value found) (apply #'value path)
-      (values (if found value (apply #'(setf value) default path))
-              t))))
+      (if found
+          (values value t)
+          (values (apply #'(setf value) default path)) nil))))
 
 (defgeneric call-with-transaction (function &key storage type designator)
   (:method (function &key storage type designator)


### PR DESCRIPTION
The second value is obviously always T as per definition, but should be better for matching the interface of `VALUE`.